### PR TITLE
fix: add .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+openapi-specedit
+*.bak
+*.swp


### PR DESCRIPTION
The standard GitHub `.gitignore` file for Go looks like this https://github.com/github/gitignore/blob/main/Go.gitignore