### PR TITLE
fix: selection node replacement

### DIFF
--- a/pkg/overlay/compare.go
+++ b/pkg/overlay/compare.go
@@ -3,10 +3,11 @@ package overlay
 import (
 	"bytes"
 	"fmt"
-	"gopkg.in/yaml.v3"
 	"log"
 	"path/filepath"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 )
 
 // Compare compares input specifications from two files and returns an overlay
@@ -139,7 +140,7 @@ func walkTreesAndCollectActions(path simplePath, y1 *yaml.Node, y2 yaml.Node) ([
 		}
 
 		return []Action{{
-			Target: path.ToJSONPath(),
+			Target: path.ToJSONPath() + "[*]", // target all elements
 			Remove: true,
 		}, {
 			Target: path.ToJSONPath(),


### PR DESCRIPTION
When we are replacing all entries in a selection node (list) we can't target and remove the parent node. Instead we should remove all entries in that parent node

Example

This output
```
actions:
  - target: $["servers"][*]
    remove: true
  - target: $["servers"]
    update:
      - url: https://api.apexfintechsolutions.com
        description: our production environment
        x-speakeasy-server-id: prod
      - url: https://dev.apexapis.com
        description: our dev environment
        x-speakeasy-server-id: dev
        
        
 Rather than this
 
 actions:
  - target: $["servers"]
    remove: true
  - target: $["servers"]
    update:
      - url: https://api.apexfintechsolutions.com/
        description: our production environment
        x-speakeasy-server-id: prod
      - url: https://dev.apexapis.com/
        description: our dev environment
        x-speakeasy-server-id: dev