### PR TITLE
fix: apply outputs overlayed spec

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,0 +1,42 @@
+name: Build cli multi-platform
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: all
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ github.sha }}
+permissions:
+  contents: read
+  packages: write

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM golang:1.23 AS builder
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o /app/overlay-cli ./main.go
+
+FROM alpine:latest
+
+COPY --from=builder /app/overlay-cli /usr/local/bin/overlay-cli
+
+ENTRYPOINT [ "overlay-cli" ]
+
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![made-with-Go](https://img.shields.io/badge/Made%20with-Go-1f425f.svg)](https://go.dev/)
-[![Go Report Card](https://goreportcard.com/badge/github.com/speakeasy-api/openapi-overlay)](https://goreportcard.com/report/github.com/speakeasy-api/openapi-overlay)
-[![GoDoc](https://godoc.org/github.com/speakeasy-api/openapi-overlay?status.svg)](https://godoc.org/github.com/speakeasy-api/openapi-overlay)
+[![Go Report Card](https://goreportcard.com/badge/github.com/vnarek/openapi-overlay)](https://goreportcard.com/report/github.com/vnarek/openapi-overlay)
+[![GoDoc](https://godoc.org/github.com/vnarek/openapi-overlay?status.svg)](https://godoc.org/github.com/vnarek/openapi-overlay)
 
 
 # OpenAPI Overlay
@@ -32,7 +32,7 @@ so it should be able to parse either YAML or JSON with the same parser.
 Install it with the `go install` command:
 
 ```sh
-go install github.com/speakeasy-api/openapi-overlay@latest
+go install github.com/vnarek/openapi-overlay@latest
 ```
 
 # Usage

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
+	"os"
+
 	"github.com/speakeasy-api/openapi-overlay/pkg/loader"
 	"github.com/spf13/cobra"
-	"os"
+	"gopkg.in/yaml.v3"
 )
 
 var (
@@ -37,7 +39,7 @@ func RunApply(cmd *cobra.Command, args []string) {
 		Dief("Failed to apply overlay to spec file %q: %v", specFile, err)
 	}
 
-	err = o.Format(os.Stdout)
+	err = yaml.NewEncoder(os.Stdout).Encode(ys)
 	if err != nil {
 		Dief("Failed to encode spec file %q: %v", specFile, err)
 	}

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"os"
 
-	"github.com/speakeasy-api/openapi-overlay/pkg/loader"
 	"github.com/spf13/cobra"
+	"github.com/vnarek/openapi-overlay/pkg/loader"
 	"gopkg.in/yaml.v3"
 )
 

--- a/cmd/compare.go
+++ b/cmd/compare.go
@@ -2,10 +2,11 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/speakeasy-api/openapi-overlay/pkg/loader"
-	"github.com/speakeasy-api/openapi-overlay/pkg/overlay"
-	"github.com/spf13/cobra"
 	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/vnarek/openapi-overlay/pkg/loader"
+	"github.com/vnarek/openapi-overlay/pkg/overlay"
 )
 
 var (

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -2,8 +2,9 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/speakeasy-api/openapi-overlay/pkg/loader"
+
 	"github.com/spf13/cobra"
+	"github.com/vnarek/openapi-overlay/pkg/loader"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/speakeasy-api/openapi-overlay
+module github.com/vnarek/openapi-overlay
 
 go 1.21.0
 
@@ -16,8 +16,6 @@ require (
 	github.com/onsi/gomega v1.27.6 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	golang.org/x/exp v0.0.0-20230811145659-89c5cff77bcb // indirect
 	golang.org/x/net v0.13.0 // indirect
-	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.10.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,6 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
-github.com/speakeasy-api/libopenapi v0.0.0-20231106110850-997f0fa6d0c5 h1:Z9UiPlPOeOTjWatTGN4RXN3r70qlZjplk0dSRL95JkI=
-github.com/speakeasy-api/libopenapi v0.0.0-20231106110850-997f0fa6d0c5/go.mod h1:dsGgChh9JOfSAQGTrB/QU/JRDFD4FwIooZRKSuOmrnM=
 github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
 github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
@@ -79,8 +77,6 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/exp v0.0.0-20230811145659-89c5cff77bcb h1:mIKbk8weKhSeLH2GmUTrvx8CjkyJmnU1wFmg59CUjFA=
-golang.org/x/exp v0.0.0-20230811145659-89c5cff77bcb/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
@@ -94,8 +90,6 @@ golang.org/x/net v0.13.0/go.mod h1:zEVYFnQC7m/vmpQFELhcD1EWkZlX69l4oqgmer6hfKA=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
-golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/speakeasy-api/openapi-overlay/cmd"
+	"github.com/vnarek/openapi-overlay/cmd"
 )
 
 func main() {

--- a/pkg/loader/overlay.go
+++ b/pkg/loader/overlay.go
@@ -2,7 +2,8 @@ package loader
 
 import (
 	"fmt"
-	"github.com/speakeasy-api/openapi-overlay/pkg/overlay"
+
+	"github.com/vnarek/openapi-overlay/pkg/overlay"
 )
 
 // LoadOverlay is a tool for loading and parsing an overlay file from the file

--- a/pkg/loader/spec.go
+++ b/pkg/loader/spec.go
@@ -2,10 +2,11 @@ package loader
 
 import (
 	"fmt"
-	"github.com/speakeasy-api/openapi-overlay/pkg/overlay"
-	"gopkg.in/yaml.v3"
 	"net/url"
 	"os"
+
+	"github.com/vnarek/openapi-overlay/pkg/overlay"
+	"gopkg.in/yaml.v3"
 )
 
 // GetOverlayExtendsPath returns the path to file if the extends URL is a file

--- a/pkg/overlay/apply_test.go
+++ b/pkg/overlay/apply_test.go
@@ -2,12 +2,13 @@ package overlay_test
 
 import (
 	"bytes"
-	"github.com/speakeasy-api/openapi-overlay/pkg/loader"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vnarek/openapi-overlay/pkg/loader"
+	"gopkg.in/yaml.v3"
 )
 
 // NodeMatchesFile is a test that marshals the YAML file from the given node,

--- a/pkg/overlay/compare_test.go
+++ b/pkg/overlay/compare_test.go
@@ -1,12 +1,13 @@
 package overlay_test
 
 import (
-	"github.com/speakeasy-api/openapi-overlay/pkg/loader"
-	"github.com/speakeasy-api/openapi-overlay/pkg/overlay"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vnarek/openapi-overlay/pkg/loader"
+	"github.com/vnarek/openapi-overlay/pkg/overlay"
 )
 
 func TestCompare(t *testing.T) {

--- a/pkg/overlay/parse_test.go
+++ b/pkg/overlay/parse_test.go
@@ -1,11 +1,12 @@
 package overlay_test
 
 import (
-	"github.com/speakeasy-api/openapi-overlay/pkg/overlay"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vnarek/openapi-overlay/pkg/overlay"
 )
 
 var expectOverlay = &overlay.Overlay{


### PR DESCRIPTION
Currently the command for overlay application is returning the formatted overlay. It should return the openapi specification after the overlay is applied instead.

PS: Thank you for this lib!