### PR TITLE
fix: issue with shared memory for updated yaml nodes

### DIFF
--- a/pkg/overlay/apply.go
+++ b/pkg/overlay/apply.go
@@ -154,7 +154,7 @@ func (o *Overlay) applyUpdateAction(root *yaml.Node, action Action, warnings *[]
 	}
 
 	for _, node := range nodes {
-		if err := updateNode(node, action.Update); err != nil {
+		if err := updateNode(node, &action.Update); err != nil {
 			return err
 		}
 	}
@@ -169,14 +169,14 @@ func (o *Overlay) applyUpdateAction(root *yaml.Node, action Action, warnings *[]
 	return nil
 }
 
-func updateNode(node *yaml.Node, updateNode yaml.Node) error {
+func updateNode(node *yaml.Node, updateNode *yaml.Node) error {
 	mergeNode(node, updateNode)
 	return nil
 }
 
-func mergeNode(node *yaml.Node, merge yaml.Node) {
+func mergeNode(node *yaml.Node, merge *yaml.Node) {
 	if node.Kind != merge.Kind {
-		*node = merge
+		*node = *clone(merge)
 		return
 	}
 	switch node.Kind {
@@ -191,7 +191,7 @@ func mergeNode(node *yaml.Node, merge yaml.Node) {
 
 // mergeMappingNode will perform a shallow merge of the merge node into the main
 // node.
-func mergeMappingNode(node *yaml.Node, merge yaml.Node) {
+func mergeMappingNode(node *yaml.Node, merge *yaml.Node) {
 NextKey:
 	for i := 0; i < len(merge.Content); i += 2 {
 		mergeKey := merge.Content[i].Value
@@ -200,16 +200,39 @@ NextKey:
 		for j := 0; j < len(node.Content); j += 2 {
 			nodeKey := node.Content[j].Value
 			if nodeKey == mergeKey {
-				mergeNode(node.Content[j+1], *mergeValue)
+				mergeNode(node.Content[j+1], mergeValue)
 				continue NextKey
 			}
 		}
 
-		node.Content = append(node.Content, merge.Content[i], mergeValue)
+		node.Content = append(node.Content, merge.Content[i], clone(mergeValue))
 	}
 }
 
 // mergeSequenceNode will append the merge node's content to the original node.
-func mergeSequenceNode(node *yaml.Node, merge yaml.Node) {
-	node.Content = append(node.Content, merge.Content...)
+func mergeSequenceNode(node *yaml.Node, merge *yaml.Node) {
+	node.Content = append(node.Content, clone(merge).Content...)
+}
+
+func clone(node *yaml.Node) *yaml.Node {
+	newNode := &yaml.Node{
+		Kind:        node.Kind,
+		Style:       node.Style,
+		Tag:         node.Tag,
+		Value:       node.Value,
+		Anchor:      node.Anchor,
+		HeadComment: node.HeadComment,
+		LineComment: node.LineComment,
+		FootComment: node.FootComment,
+	}
+	if node.Alias != nil {
+		newNode.Alias = clone(node.Alias)
+	}
+	if node.Content != nil {
+		newNode.Content = make([]*yaml.Node, len(node.Content))
+		for i, child := range node.Content {
+			newNode.Content[i] = clone(child)
+		}
+	}
+	return newNode
 }

--- a/pkg/overlay/compare_test.go
+++ b/pkg/overlay/compare_test.go
@@ -5,7 +5,6 @@ import (
 	"github.com/speakeasy-api/openapi-overlay/pkg/overlay"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"os"
 	"testing"
 )
 
@@ -29,7 +28,7 @@ func TestCompare(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Uncomment this if we've improved the output
-	os.WriteFile("testdata/overlay-generated.yaml", []byte(o2s), 0644)
+	//os.WriteFile("testdata/overlay-generated.yaml", []byte(o2s), 0644)
 	assert.Equal(t, o1s, o2s)
 
 	// round trip it

--- a/pkg/overlay/testdata/openapi-overlayed.yaml
+++ b/pkg/overlay/testdata/openapi-overlayed.yaml
@@ -76,6 +76,7 @@ paths:
       security: []
       tags:
         - authentication
+        - dont-add-x-drop-false
       requestBody:
         required: true
         content:

--- a/pkg/overlay/testdata/openapi-strict-onechange.yaml
+++ b/pkg/overlay/testdata/openapi-strict-onechange.yaml
@@ -72,6 +72,7 @@ paths:
       security: []
       tags:
         - authentication
+        - dont-add-x-drop-false
       requestBody:
         required: true
         content:

--- a/pkg/overlay/testdata/openapi.yaml
+++ b/pkg/overlay/testdata/openapi.yaml
@@ -73,6 +73,7 @@ paths:
       security: []
       tags:
         - authentication
+        - dont-add-x-drop-false
       requestBody:
         required: true
         content:


### PR DESCRIPTION
An overlay like:

```
overlay: 1.0.0
x-speakeasy-jsonpath: rfc9535
info:
    title: example overlay
    version: 0.0.0
actions: 
  - target: $.paths.*.*
    update: 
      x-drop: true
  - target: $.paths.*[?@.operationId == 'findPetsByStatus']
    update:
      x-drop: false
```

Would previously re-use memory for `x-drop: true` across the document, which means that subsequent updates would affect all nodes.

This makes sure we clone the yaml node before inserting it into the document.