### PR TITLE
perf: speed up overlay performance ~200-40000x depending on the size of the document

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/speakeasy-api/openapi-overlay
 
-go 1.22
+go 1.24
 
 require (
 	github.com/speakeasy-api/jsonpath v0.6.0

--- a/pkg/overlay/apply_test.go
+++ b/pkg/overlay/apply_test.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"github.com/speakeasy-api/jsonpath/pkg/jsonpath"
 	"github.com/speakeasy-api/openapi-overlay/pkg/loader"
+	"github.com/speakeasy-api/openapi-overlay/pkg/overlay"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 	"os"
+	"strconv"
 	"testing"
 )
 
@@ -75,6 +77,195 @@ func TestApplyToStrict(t *testing.T) {
 	assert.Len(t, warnings, 1)
 	assert.Equal(t, "update action (2 / 2) target=$.info.title: does nothing", warnings[0])
 	NodeMatchesFile(t, node, "testdata/openapi-strict-onechange.yaml")
+
+	node, err = loader.LoadSpecification("testdata/openapi.yaml")
+	require.NoError(t, err)
+
+	o, err = loader.LoadOverlay("testdata/overlay.yaml")
+	require.NoError(t, err)
+
+	err = o.ApplyTo(node)
+	assert.NoError(t, err)
+
+	NodeMatchesFile(t, node, "testdata/openapi-overlayed.yaml")
+
+}
+
+func BenchmarkApplyToStrict(b *testing.B) {
+	openAPIBytes, err := os.ReadFile("testdata/openapi.yaml")
+	require.NoError(b, err)
+	overlayBytes, err := os.ReadFile("testdata/overlay-zero-change.yaml")
+	require.NoError(b, err)
+
+	var specNode yaml.Node
+	err = yaml.NewDecoder(bytes.NewReader(openAPIBytes)).Decode(&specNode)
+	require.NoError(b, err)
+
+	// Load overlay from bytes
+	var o overlay.Overlay
+	err = yaml.NewDecoder(bytes.NewReader(overlayBytes)).Decode(&o)
+	require.NoError(b, err)
+
+	// Apply overlay to spec
+	for b.Loop() {
+		_, _ = o.ApplyToStrict(&specNode)
+	}
+}
+
+func BenchmarkApplyToStrictBySize(b *testing.B) {
+	// Read the base OpenAPI spec
+	openAPIBytes, err := os.ReadFile("testdata/openapi.yaml")
+	require.NoError(b, err)
+
+	// Read the overlay spec
+	overlayBytes, err := os.ReadFile("testdata/overlay-zero-change.yaml")
+	require.NoError(b, err)
+
+	// Decode the base spec
+	var baseSpec yaml.Node
+	err = yaml.NewDecoder(bytes.NewReader(openAPIBytes)).Decode(&baseSpec)
+	require.NoError(b, err)
+
+	// Find the paths node and a path to duplicate
+	pathsNode := findPathsNode(&baseSpec)
+	require.NotNil(b, pathsNode)
+
+	// Get the first path item to use as template
+	var templatePath *yaml.Node
+	var templateKey string
+	for i := 0; i < len(pathsNode.Content); i += 2 {
+		if pathsNode.Content[i].Kind == yaml.ScalarNode && pathsNode.Content[i].Value[0] == '/' {
+			templateKey = pathsNode.Content[i].Value
+			templatePath = pathsNode.Content[i+1]
+			break
+		}
+	}
+	require.NotNil(b, templatePath)
+
+	// Target sizes: 2KB, 20KB, 200KB, 2MB, 20MB
+	targetSizes := []struct {
+		size int
+		name string
+	}{
+		{2 * 1024, "2KB"},
+		{20 * 1024, "20KB"},
+		{200 * 1024, "200KB"},
+		{2000 * 1024, "2M"},
+	}
+
+	// Calculate the base document size
+	var baseBuf bytes.Buffer
+	enc := yaml.NewEncoder(&baseBuf)
+	err = enc.Encode(&baseSpec)
+	require.NoError(b, err)
+	baseSize := baseBuf.Len()
+
+	// Calculate the size of a single path item by encoding it
+	var pathBuf bytes.Buffer
+	pathEnc := yaml.NewEncoder(&pathBuf)
+	tempNode := &yaml.Node{
+		Kind: yaml.MappingNode,
+		Content: []*yaml.Node{
+			{Kind: yaml.ScalarNode, Value: templateKey + "-test"},
+			cloneNode(templatePath),
+		},
+	}
+	err = pathEnc.Encode(tempNode)
+	require.NoError(b, err)
+	// Approximate size contribution of one path (accounting for YAML structure)
+	pathItemSize := pathBuf.Len() - 10 // Subtract some overhead
+
+	for _, target := range targetSizes {
+		b.Run(target.name, func(b *testing.B) {
+			// Create a copy of the base spec
+			specCopy := cloneNode(&baseSpec)
+			pathsNodeCopy := findPathsNode(specCopy)
+
+			// Calculate how many paths we need to add
+			bytesNeeded := target.size - baseSize
+			pathsToAdd := 0
+			if bytesNeeded > 0 {
+				pathsToAdd = bytesNeeded / pathItemSize
+				// Add a few extra to ensure we exceed the target
+				pathsToAdd += 5
+			}
+
+			// Add the calculated number of path duplicates
+			for i := 0; i < pathsToAdd; i++ {
+				newPathKey := yaml.Node{Kind: yaml.ScalarNode, Value: templateKey + "-duplicate-" + strconv.Itoa(i)}
+				newPathValue := cloneNode(templatePath)
+				pathsNodeCopy.Content = append(pathsNodeCopy.Content, &newPathKey, newPathValue)
+			}
+
+			// Verify final size
+			var finalBuf bytes.Buffer
+			finalEnc := yaml.NewEncoder(&finalBuf)
+			err = finalEnc.Encode(specCopy)
+			require.NoError(b, err)
+			actualSize := finalBuf.Len()
+			b.Logf("OpenAPI size: %d bytes (target: %d, paths added: %d)", actualSize, target.size, pathsToAdd)
+
+			// Load overlay
+			var o overlay.Overlay
+			err = yaml.NewDecoder(bytes.NewReader(overlayBytes)).Decode(&o)
+			require.NoError(b, err)
+
+			specForTest := cloneNode(specCopy)
+			// Run the benchmark
+			b.ResetTimer()
+			for b.Loop() {
+				_, _ = o.ApplyToStrict(specForTest)
+			}
+		})
+	}
+}
+
+// Helper function to find the paths node in the OpenAPI spec
+func findPathsNode(node *yaml.Node) *yaml.Node {
+	if node.Kind == yaml.DocumentNode && len(node.Content) > 0 {
+		node = node.Content[0]
+	}
+
+	if node.Kind != yaml.MappingNode {
+		return nil
+	}
+
+	for i := 0; i < len(node.Content); i += 2 {
+		if node.Content[i].Value == "paths" {
+			return node.Content[i+1]
+		}
+	}
+	return nil
+}
+
+// Helper function to deep clone a YAML node
+func cloneNode(node *yaml.Node) *yaml.Node {
+	if node == nil {
+		return nil
+	}
+
+	clone := &yaml.Node{
+		Kind:        node.Kind,
+		Style:       node.Style,
+		Tag:         node.Tag,
+		Value:       node.Value,
+		Anchor:      node.Anchor,
+		Alias:       node.Alias,
+		HeadComment: node.HeadComment,
+		LineComment: node.LineComment,
+		FootComment: node.FootComment,
+		Line:        node.Line,
+		Column:      node.Column,
+	}
+
+	if node.Content != nil {
+		clone.Content = make([]*yaml.Node, len(node.Content))
+		for i, child := range node.Content {
+			clone.Content[i] = cloneNode(child)
+		}
+	}
+
+	return clone
 }
 
 func TestApplyToOld(t *testing.T) {

--- a/pkg/overlay/testdata/overlay-zero-change.yaml
+++ b/pkg/overlay/testdata/overlay-zero-change.yaml
@@ -1,0 +1,10 @@
+overlay: 1.0.0
+x-speakeasy-jsonpath: rfc9535
+info:
+  title: Drinks Overlay
+  version: 0.0.0
+actions:
+  - target: $.paths["/drink/{name}"].get.summary
+    update: "Read a drink."
+  - target: $.paths["/drink/{name}"].get.summary
+    update: "Get a drink."


### PR DESCRIPTION
Context:

Strict Mode effectively produced a warning when there was an overlay action that didn't do anything.
It was done by serialising the document before and after each change and doing a comparison. Super inefficient.
This makes it work by returning back a "didChange" boolean all the way from applyNode depending on the kind of change that happened.


From:

cpu: Apple M3 Max
BenchmarkApplyToStrictBySize
BenchmarkApplyToStrictBySize/2KB
    apply_test.go:206: OpenAPI size: 16911 bytes (target: 2048, paths added: 0)
BenchmarkApplyToStrictBySize/2KB-14         	     738	   1600568 ns/op
BenchmarkApplyToStrictBySize/20KB
    apply_test.go:206: OpenAPI size: 22741 bytes (target: 20480, paths added: 16)
BenchmarkApplyToStrictBySize/20KB-14        	     493	   2377933 ns/op
BenchmarkApplyToStrictBySize/200KB
    apply_test.go:206: OpenAPI size: 245551 bytes (target: 204800, paths added: 625)
BenchmarkApplyToStrictBySize/200KB-14       	      48	  23456246 ns/op
BenchmarkApplyToStrictBySize/2M
    apply_test.go:206: OpenAPI size: 2477637 bytes (target: 2048000, paths added: 6708)
BenchmarkApplyToStrictBySize/2M-14          	       5	 235112558 ns/op
PASS
To:

BenchmarkApplyToStrictBySize
BenchmarkApplyToStrictBySize/2KB
    apply_test.go:206: OpenAPI size: 16911 bytes (target: 2048, paths added: 0)
BenchmarkApplyToStrictBySize/2KB-14         	  200113	      6067 ns/op
BenchmarkApplyToStrictBySize/20KB
    apply_test.go:206: OpenAPI size: 22741 bytes (target: 20480, paths added: 16)
BenchmarkApplyToStrictBySize/20KB-14        	  192753	      6248 ns/op
BenchmarkApplyToStrictBySize/200KB
    apply_test.go:206: OpenAPI size: 245551 bytes (target: 204800, paths added: 625)
BenchmarkApplyToStrictBySize/200KB-14       	  170931	      7046 ns/op
BenchmarkApplyToStrictBySize/2M
    apply_test.go:206: OpenAPI size: 2477637 bytes (target: 2048000, paths added: 6708)
BenchmarkApplyToStrictBySize/2M-14          	  216870	      5873 ns/op
PASS

Size | Before (ns/op) | After (ns/op) | Speedup
-- | -- | -- | --
2KB | 1,600,568 | 6,067 | 263.8x
20KB | 2,377,933 | 6,248 | 380.6x
200KB | 23,456,246 | 7,046 | 3329.1x
2MB | 235,112,558 | 5,873 | 40032.8x
